### PR TITLE
chore(terraform): make model_uuid required in all modules (charmkeeper)

### DIFF
--- a/terraform/charm/variables.tf
+++ b/terraform/charm/variables.tf
@@ -28,7 +28,6 @@ variable "constraints" {
 variable "model_uuid" {
   description = "Reference to a juju model's uuid."
   type        = string
-  default     = ""
 }
 
 variable "revision" {

--- a/terraform/product/modules/oauth-external-idp-integrator/variables.tf
+++ b/terraform/product/modules/oauth-external-idp-integrator/variables.tf
@@ -29,7 +29,6 @@ variable "constraints" {
 variable "model_uuid" {
   description = "Reference to a juju model's uuid."
   type        = string
-  default     = ""
 }
 
 variable "revision" {

--- a/terraform/product/modules/redis-k8s/variables.tf
+++ b/terraform/product/modules/redis-k8s/variables.tf
@@ -28,7 +28,6 @@ variable "constraints" {
 variable "model_uuid" {
   description = "Reference to a juju model's uuid."
   type        = string
-  default     = ""
 }
 
 variable "revision" {

--- a/terraform/product/modules/s3-integrator/variables.tf
+++ b/terraform/product/modules/s3-integrator/variables.tf
@@ -28,7 +28,6 @@ variable "constraints" {
 variable "model_uuid" {
   description = "Reference to a juju model's uuid."
   type        = string
-  default     = ""
 }
 
 variable "revision" {


### PR DESCRIPTION
## Summary

Remove `default = ""` from `model_uuid` variable in the charm module and product submodules (redis-k8s, s3-integrator, oauth-external-idp-integrator).

## Rationale

Deploying without a valid model UUID would always fail, so the variable should be **required** rather than silently defaulting to an empty string. This aligns with our team's terraform standards where `model_uuid` must not have a default value.

## Changes

- `terraform/charm/variables.tf` — removed `default = ""` from `model_uuid`
- `terraform/product/modules/redis-k8s/variables.tf` — same
- `terraform/product/modules/s3-integrator/variables.tf` — same
- `terraform/product/modules/oauth-external-idp-integrator/variables.tf` — same

---
*Automated by charmkeeper*