### PR TITLE
[URGENT] fix: add CSRF_TRUSTED_ORIGINS to prevent login CSRF failures

### DIFF
--- a/configuration.py
+++ b/configuration.py
@@ -19,6 +19,10 @@ if 'DJANGO_AWS_ENDPOINT_URL' in os.environ:
 #
 ALLOWED_HOSTS = json.loads(os.environ.get("DJANGO_ALLOWED_HOSTS", "[]"))
 
+# CSRF_TRUSTED_ORIGINS must contain the same hostnames as ALLOWED_HOSTS for CSRF protection to work
+# when NetBox is behind a reverse proxy (e.g. Traefik ingress).
+CSRF_TRUSTED_ORIGINS = ALLOWED_HOSTS[:]
+
 # PostgreSQL database configuration. See the Django documentation for a complete list of available parameters:
 #   https://docs.djangoproject.com/en/stable/ref/settings/#databases
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Place any unreleased changes here, that are subject to release in coming versions :).
+* Add `CSRF_TRUSTED_ORIGINS` setting to the configuration file to prevent
+  login failures when NetBox is behind a reverse proxy.
 
 ## 2025-12-17
 

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -1,0 +1,92 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Unit tests for the NetBox Django configuration module."""
+
+import importlib.util
+import json
+import os
+import pathlib
+import sys
+
+import pytest
+
+CONFIG_PATH = pathlib.Path(os.path.dirname(__file__)).parent.parent / "configuration.py"
+
+
+def _load_configuration(env: dict[str, str]) -> dict:
+    """Load configuration.py as a module with the given environment variables.
+
+    Args:
+        env: additional environment variables to set.
+
+    Returns:
+        The module's namespace as a dictionary.
+    """
+    module_name = f"_test_config_{abs(hash(frozenset(env.items())))}"
+    for key, value in env.items():
+        os.environ[key] = value
+    os.environ["DJANGO_SECRET_KEY"] = "test-secret-key-12345"
+    spec = importlib.util.spec_from_file_location(module_name, CONFIG_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return vars(module)
+
+
+class TestCsrfTrustedOrigins:
+    """Tests for the CSRF_TRUSTED_ORIGINS setting."""
+
+    def test_empty_allowed_hosts(self):
+        """
+        arrange: No DJANGO_ALLOWED_HOSTS env var is set.
+        act: Load the configuration module.
+        assert: CSRF_TRUSTED_ORIGINS should be an empty list.
+        """
+        config = _load_configuration({})
+        assert config["CSRF_TRUSTED_ORIGINS"] == []
+
+    def test_matches_allowed_hosts(self):
+        """
+        arrange: DJANGO_ALLOWED_HOSTS is set to ["example.com", "netbox.local"].
+        act: Load the configuration module.
+        assert: CSRF_TRUSTED_ORIGINS should contain the same values as ALLOWED_HOSTS.
+        """
+        hosts = ["example.com", "netbox.local"]
+        config = _load_configuration({"DJANGO_ALLOWED_HOSTS": json.dumps(hosts)})
+        assert config["CSRF_TRUSTED_ORIGINS"] == hosts
+
+    def test_independent_copy(self):
+        """
+        arrange: DJANGO_ALLOWED_HOSTS is set to ["example.com"].
+        act: Load the configuration module.
+        assert: CSRF_TRUSTED_ORIGINS should be an independent copy.
+        """
+        config = _load_configuration({"DJANGO_ALLOWED_HOSTS": '["example.com"]'})
+        assert config["CSRF_TRUSTED_ORIGINS"] is not config["ALLOWED_HOSTS"]
+
+    def test_with_single_host(self):
+        """
+        arrange: DJANGO_ALLOWED_HOSTS is set to ["netbox.example.com"].
+        act: Load the configuration module.
+        assert: CSRF_TRUSTED_ORIGINS should contain exactly that host.
+        """
+        config = _load_configuration({"DJANGO_ALLOWED_HOSTS": '["netbox.example.com"]'})
+        assert config["CSRF_TRUSTED_ORIGINS"] == ["netbox.example.com"]
+
+    def test_with_multiple_hosts(self):
+        """
+        arrange: DJANGO_ALLOWED_HOSTS is set to multiple hosts.
+        act: Load the configuration module.
+        assert: CSRF_TRUSTED_ORIGINS should contain all of them.
+        """
+        config = _load_configuration(
+            {"DJANGO_ALLOWED_HOSTS": '["host1.example.com", "host2.example.com", "host3.example.com"]'}
+        )
+        assert config["CSRF_TRUSTED_ORIGINS"] == [
+            "host1.example.com",
+            "host2.example.com",
+            "host3.example.com",
+        ]

--- a/tox.ini
+++ b/tox.ini
@@ -78,8 +78,11 @@ commands =
 
 [testenv:unit]
 description = Run unit tests
+deps =
+    pytest
+    -r {tox_root}/requirements.txt
 commands =
-    python -c ""
+    pytest -v --tb native --log-cli-level=INFO {posargs} {[vars]tests_path}/unit
 
 [testenv:static]
 description = Run static type checks


### PR DESCRIPTION
### Overview

Add missing CSRF_TRUSTED_ORIGINS setting, derived from ALLOWED_HOSTS, which already contains the ingress hostname added by the charm.

### Rationale

Setting CSRF_TRUSTED_ORIGINS is required for Django CSRF protection to work when NetBox is behind a reverse proxy such as Traefik ingress. Without this setting, login fails with Origin checking failed errors.

Fixes: canonical/netbox-k8s-operator#86

### Juju Events Changes

None

### Module Changes

None

### Library Changes

None

### Checklist

- [x] The [charm style guide](https://documentation.ubuntu.com/juju/3.6/reference/charm/charm-development-best-practices/) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [x] The `docs/changelog.md` is updated with user-relevant changes.

<!-- Explanation for any unchecked items above -->

Not sure where to update the charmhub documentation.